### PR TITLE
Add fswitchfnames option that allows mutating the base filename when looking for a companion file.

### DIFF
--- a/doc/fswitch.txt
+++ b/doc/fswitch.txt
@@ -103,7 +103,7 @@ get that move on to |fswitch-configure|.
 	'fswitchlocs' variable.
 
 							*'fswitchlocs'*
-'fswitchlocs'	string	(default depends on filen in current buffer)
+'fswitchlocs'	string	(default depends on file in current buffer)
 		local to buffer
 
 	The 'fswitchlocs' variable contains a set of directives that indicate
@@ -208,6 +208,30 @@ get that move on to |fswitch-configure|.
 	The default locations are currently set to "./" or ".\" depending on
 	what slash your configuration evaluates to.
 
+							*'fswitchfnames'*
+'fswitchfnames'	string	(default depends on file in current buffer)
+		local to buffer
+
+	The 'fswitchfnames' variable contains a comma-separated list
+	of possible substitution patterns over the base filename (without path
+	and extension) that should be formulated when trying to find the
+	alternate file.  The format of the substitution pattern is the same
+	as |fswitch-reg|.
+
+	This may be useful when the companion file may can be formulated by
+	adding a suffix to the base filename. For instance, when the companion
+	of MyClass.java is MyClassTest.java.
+	
+	For example:
+>
+		" Create the destination filename by appending 'Test'
+		" to the filename
+		:let b:fswitchfnames = '/$/Test/'
+
+		" Create the destination filename by removing 'Test'
+		" from the end of the filename.
+		:let b:fswitchfnames = '/Test$//'
+<
 							*'fswitchnonewfiles'*
 'fsnonewfiles'
 		string	(default off)


### PR DESCRIPTION
Hi Derek,

I've implemented a new feature (that is useful at least for me) and hope that you can integrate it.

The idea is that I would like to use FSwitch for switching between implementation and test code. For SomeFile.scala my test file would be called SomeFileTest.scala. It would also be in a different directory (but b:fswitchlocs takes care of that). So I thought to introduce a new option that allows substitution over the base filename. Here is how I use it:

```
au FileType scala let b:fswitchdst = 'scala'

" Matches scala files that do not end with Test.scala
au BufEnter *\(Test\)\@!.scala let b:fswitchlocs = 'reg:+/main/scala+/test/scala/+' | let b:fswitchfnames='/$/Test/'

" Matches scala files that do end with Test.scala
au BufEnter *Test.scala let b:fswitchlocs = 'reg:+/test/scala+/main/scala/+' | let b:fswitchfnames='/Test$//'
```
