### PR TITLE
Fix behavior for specific user settings (spr, sb and switcbuf=useopen/usetab)

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -297,6 +297,19 @@ function! FSwitch(filename, precmd)
             let newpath = FSReturnCompanionFilenameString(a:filename)
         endif
     endif
+    if &switchbuf =~ "^use"
+        let i = 1
+        let bufnum = winbufnr(i)
+        while bufnum != -1
+            let filename = fnamemodify(bufname(bufnum), ':p')
+            if filename == newpath
+                execute ":sbuffer " .  filename
+                return
+            endif
+            let i += 1
+            let bufnum = winbufnr(i)
+        endwhile
+    endif
     if openfile == 1
         if newpath != ''
             if strlen(a:precmd) != 0
@@ -325,11 +338,11 @@ augroup END
 "
 com! FSHere       :call FSwitch('%', '')
 com! FSRight      :call FSwitch('%', 'wincmd l')
-com! FSSplitRight :call FSwitch('%', 'vsplit | wincmd l')
+com! FSSplitRight :call FSwitch('%', 'let curspr=&spr | set nospr | vsplit | wincmd l | if curspr | set spr | endif')
 com! FSLeft       :call FSwitch('%', 'wincmd h')
-com! FSSplitLeft  :call FSwitch('%', 'vsplit | wincmd h')
+com! FSSplitLeft  :call FSwitch('%', 'let curspr=&spr | set nospr | vsplit | wincmd h | if curspr | set spr | endif')
 com! FSAbove      :call FSwitch('%', 'wincmd k')
-com! FSSplitAbove :call FSwitch('%', 'split | wincmd k')
+com! FSSplitAbove :call FSwitch('%', 'let cursb=&sb | set nosb | split | wincmd k | if cursb | set sb | endif')
 com! FSBelow      :call FSwitch('%', 'wincmd j')
-com! FSSplitBelow :call FSwitch('%', 'split | wincmd j')
+com! FSSplitBelow :call FSwitch('%', 'let cursb=&sb | set nosb | split | wincmd j | if cursb | set sb | endif')
 


### PR DESCRIPTION
1. Commands FSSplitLeft (..Right.., ..Above.. and ..Below..) will
   temporarily unset 'splitright' and 'splitbelow' options and revert
   them back after splitting. This will fix behaviour of these commands
   when the options are set.
2. Option 'switchbuf' is checked in function FSwitch() to ensure that
   already open buffers will be jumped to rather than opening a new
   window when its value is 'useopen' or 'usetab'. Jumping to an already
   existing buffer is achieved by using command sbuffer which knows how
   to do when switchbuf is 'useopen' or 'usetab' (similar solution can
   be found in a.vim).
