### PR TITLE
Restore buffer if matched file is already open

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -315,7 +315,14 @@ function! FSwitch(filename, precmd)
             if strlen(a:precmd) != 0
                 execute a:precmd
             endif
-            execute 'edit ' . fnameescape(newpath)
+            
+            let s:fname = fnameescape(newpath)
+
+            if (strlen(bufname(s:fname))) > 0
+                execute 'buffer ' . s:fname
+            else
+                execute 'edit ' . s:fname
+            endif
         else
             echoerr "Alternate has evaluated to nothing.  See :h fswitch-empty for more info."
         endif


### PR DESCRIPTION
Hi Derek,

this change will first lookup the matched file in the buffer list and uses either "buffer" or "edit".

Cheers, 
Sebastian
