### PR TITLE
Switch buffer if file is opened instead of calling edit all the time.

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -315,7 +315,11 @@ function! FSwitch(filename, precmd)
             if strlen(a:precmd) != 0
                 execute a:precmd
             endif
-            execute 'edit ' . fnameescape(newpath)
+            if bufexists(newpath)
+                execute 'buffer ' . fnameescape(newpath)
+            else
+                execute 'edit ' . fnameescape(newpath)
+            endif
         else
             echoerr "Alternate has evaluated to nothing.  See :h fswitch-empty for more info."
         endif


### PR DESCRIPTION
This fix the problem where the cursor would always return at the beginning of the file when switching to an already opened file.
