### PR TITLE
Fix problem with opening symlink buffers

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -316,7 +316,7 @@ function! FSwitch(filename, precmd)
                 execute a:precmd
             endif
             if bufexists(newpath)
-                execute 'buffer ' . fnameescape(newpath)
+                execute 'buffer ' . bufnr(newpath)
             else
                 execute 'edit ' . fnameescape(newpath)
             endif

--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -282,7 +282,7 @@ endfunction
 "
 function! FSwitch(filename, precmd)
     if !exists("b:fswitchdst") || strlen(b:fswitchdst) == 0
-        throw 'b:fswitchdst not set - read :help fswitch'
+        doautocmd fswitch_au_group BufEnter
     endif
     if (!exists("b:fswitchlocs")   || strlen(b:fswitchlocs) == 0) &&
      \ (!exists("b:fsdisablegloc") || b:fsdisablegloc == 0)


### PR DESCRIPTION
If you have a file `a.h` and a file `a.c` in a directory `./a` and then create symlinks to the files in a directory `./b`, then open `./a/a.h` and `./b/a.c`, FSwitch fails to switch between the two files with `E94: No matching buffer`. The solution is to use `bufnr()` instead of the filename for the buffer command which ensures you get the buffer number that was checked in `bufexists()`.
