### PR TITLE
Fix 2 issues: (1) buffer that we switched to remains unlisted; (2) problem with symlink buffers

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -315,11 +315,7 @@ function! FSwitch(filename, precmd)
             if strlen(a:precmd) != 0
                 execute a:precmd
             endif
-            if bufexists(newpath)
-                execute 'buffer ' . fnameescape(newpath)
-            else
-                execute 'edit ' . fnameescape(newpath)
-            endif
+            execute 'edit ' . fnameescape(newpath)
         else
             echoerr "Alternate has evaluated to nothing.  See :h fswitch-empty for more info."
         endif


### PR DESCRIPTION
This reverts commit 8a8fa09 ("Switch buffer if file is already opened instead of always call edit.")

The problem that it is supposed to address ("the cursor always returns
at the beginning of the file") is not specific to fswitch and can be
fixed by an autocommand in a more generic way (``autocmd BufWinEnter * exe
"normal! g`\""``).

On the other hand, this commit introduces two problems:
  - when switching to an unlisted buffer, it remains unlisted. This
    leads, for example, to counterintuitive behavior in buftabline (and
    probably other similar plugins): currently opened buffer is not
    in buffer list.
  - problem with opening symlink buffers (derekwyatt/vim-fswitch#11)

Reverting it solves both.