### PR TITLE
Look-up buffer by its exact name

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -317,7 +317,7 @@ function! FSwitch(filename, precmd)
             endif
             let s:fname = fnameescape(newpath)
 
-            if (strlen(bufname(s:fname))) > 0
+            if (strlen(bufname("^" . s:fname . "$"))) > 0
                 execute 'buffer ' . s:fname
             else
                 execute 'edit ' . s:fname


### PR DESCRIPTION
**Problem**

When the target name is a prefix of the source name, switch would not happen as we would ask vim to switch to a non existent buffer.

**Example**

OCaml's ".mli" files and ".ml" files.

**Fix**

Check the existence of the buffer by its full name.