### PR TITLE
fix bug ,now can switch btw catkin_ws

### DIFF
--- a/plugin/fswitch.vim
+++ b/plugin/fswitch.vim
@@ -209,10 +209,11 @@ function! s:FSGetAlternateFilename(filepath, filename, newextension, location, m
                 if cmd == 'reg'
                     if a:mustmatch == 1 && match(a:filepath, part1) == -1
                         "let path = ""
-                        paths = []
+                        call add(paths, "")
                     else
-                        "let path = substitute(a:filepath, part1, part2, flags) . s:os_slash .
-                                    "\ a:filename . '.' . a:newextension
+                        let path = substitute(a:filepath, part1, part2, flags) . s:os_slash .
+                                    \ a:filename . '.' . a:newextension
+                        call add(paths, path) 
                         for raw_path in s:FSGetAlternateFilenameList(a:filepath, part1, part2)
                             call add(paths, raw_path . s:os_slash .
                                     \ a:filename . '.' . a:newextension)
@@ -221,7 +222,7 @@ function! s:FSGetAlternateFilename(filepath, filename, newextension, location, m
                 elseif cmd == 'ifrel'
                     if match(a:filepath, part1) == -1
                         "let path = ""
-                        paths = []
+                        call add(paths, "")
                     else
                         let path = a:filepath . s:os_slash . part2 .
                                      \ s:os_slash . a:filename . '.' . a:newextension
@@ -230,7 +231,7 @@ function! s:FSGetAlternateFilename(filepath, filename, newextension, location, m
                 elseif cmd == 'ifabs'
                     if match(a:filepath, part1) == -1
                         "let path = ""
-                        paths = []
+                        call add(paths, "")
                     else
                         let path = part2 . s:os_slash . a:filename . '.' . a:newextension
                         call add(paths, path)


### PR DESCRIPTION
these is a problem
if the file path have more than one key which like "include",or "src", then the substitute function just will replace the first key which it matched.
so i modify the script ,and work well.
but there is still a bug, when the key in the end of the path 
but i am a new guy for vim script. so, the code maybe not friendly when you review that